### PR TITLE
Improve mobile readabilty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ typings/
 
 # next.js build output
 .next
+
+.idea/

--- a/src/components/projects-list/projects-list.css
+++ b/src/components/projects-list/projects-list.css
@@ -4,10 +4,10 @@
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: center;
+  align-items: start;
 }
 
-/* 
+/*
 Make CSS Fill reaminaing Dynamic height, but still be scrollable
 https://stackoverflow.com/questions/22085498/make-a-div-fill-the-remaining-dynamic-height-and-scroll-without-javascript */
 .project-list__virtual-list-wrapper {
@@ -28,7 +28,7 @@ https://stackoverflow.com/questions/22085498/make-a-div-fill-the-remaining-dynam
 }
 
 .project-list__project {
-  height: 80px;
+  min-height: 80px;
   width: 95%;
   display: flex;
   justify-content: flex-start;
@@ -64,7 +64,17 @@ https://stackoverflow.com/questions/22085498/make-a-div-fill-the-remaining-dynam
   margin-bottom: 5px;
 
   flex: 1;
+}
+
+.project-list__project__title {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.project-list__project__description {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
 }

--- a/src/components/projects-list/projects-list.js
+++ b/src/components/projects-list/projects-list.js
@@ -7,10 +7,6 @@ export default class ProjectsList extends Component {
   render() {
     return (
       <div class="project-list">
-        <div>
-          <b>{this.props.projects.length} projects</b>
-        </div>
-
         {this.props.projects.length === 0 ? (
           ""
         ) : (

--- a/src/pages/home/home.css
+++ b/src/pages/home/home.css
@@ -16,6 +16,11 @@
   }
 }
 
+.search-stats {
+  border-bottom: 1px solid;
+  padding-bottom: 8px;
+}
+
 .search-input {
   text-align: center;
   padding: 10px;
@@ -24,7 +29,7 @@
   border: none;
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
 
-  margin-bottom: 20px;
+  margin-bottom: 13px;
   margin-top: 20px;
   margin-left: 10px;
   margin-right: 10px;

--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -63,6 +63,10 @@ export default class Home extends Component {
           onInput={event => this.onInput(event)}
         />
 
+        <div class="search-stats">
+          <b>{this.state.results.length} projects</b>
+        </div>
+
         <ProjectsList projects={this.state.results} />
       </div>
     );


### PR DESCRIPTION
Hi, there. Thank's for putting this list together. However I had a hard time skimming the list on mobile, because each description was only a couple of words before the ellipsis ...

I thought I create a PR bringing a line clamp with 3 into the list. Here is a comparison on Iphone SE:

![madewithwebassembly com_(iPhone 5_SE)](https://user-images.githubusercontent.com/16897125/112623015-19f31b80-8e2c-11eb-86f3-5a3214376ba8.png)

![0 0 0 0_45889_(iPhone 5_SE) (1)](https://user-images.githubusercontent.com/16897125/112623023-1cee0c00-8e2c-11eb-8ed5-e32377d12fa9.png)
