### PR TITLE
Correct typo in repo reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ git clone git@github.com:<your username>/made-with-webassembly.git
    newly created local repository directory and run:
 
 ```shell
-git remote add upstream git@github.com:torch2424/wasm-by-example.git
+git remote add upstream git@github.com:torch2424/made-with-webassembly.git
 ```
 
 7. Fetch data from the `upstream` remote:


### PR DESCRIPTION
Just noticed that in the one-time setup instructions, when the upstream remote repo is added, the `git remote add upstream` command pointed to `wasm-by-example.git` and not `made-with-webassembly.git`